### PR TITLE
replaced 2 CMD commands with 2 RUN commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 AS fastai
 
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 
@@ -40,8 +40,8 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV USER fastai
 
 
-CMD source activate fastai
-CMD source ~/.bashrc
+RUN /bin/bash -c "source /opt/conda/bin/activate fastai"
+RUN /bin/bash -c "source ~/.bashrc"
 
 WORKDIR /data
 


### PR DESCRIPTION
Replaced 2 CMD commands with 2 RUN commands as CMD is supposed to only be mentioned once in one Dockerfile. Per [the official documentation](https://docs.docker.com/engine/reference/builder/#cmd),
> There can only be one `CMD` instruction in a `Dockerfile`. If you list more than one `CMD` then only the last `CMD` will take effect.

The commands have also been altered to make them work as simply replacing 'CMD' with 'RUN' results in errors.

Also added 'fastai' name to the image.